### PR TITLE
Add "HookId" as part of the `/generate` response.

### DIFF
--- a/sinhook.rb
+++ b/sinhook.rb
@@ -77,8 +77,8 @@ class SinHook < Sinatra::Base
     send method, "/hook/generate", :provides => :json do
 
       hook_id = settings.hooks.create
-      response_message(:success, "Hook ID: #{hook_id}")
-
+      "{\"Response\": \"#{MESSAGE_TYPE[:success]}\",\"Message\": \"Hook ID: #{hook_id}\", \"HookId\":\"#{hook_id}\"}"
+      
     end
 
   end


### PR DESCRIPTION
Simplify programmatic generation of hooks by including the generated hook id with the response message.